### PR TITLE
Change Port to PORT

### DIFF
--- a/server.js
+++ b/server.js
@@ -26,7 +26,7 @@ app.get("/", function (req, res) {
 
 
 
-app.listen(process.env.Port || 8080, function () {
+app.listen(process.env.PORT || 8080, function () {
     console.log("Server is running");
 });
 


### PR DESCRIPTION
Environment variables are case sensitive.  This should fix the server from crashing on Heroku.